### PR TITLE
extraced code to generateBuildConsistentID to generate consistent IDs between builds.

### DIFF
--- a/generate-manuals.js
+++ b/generate-manuals.js
@@ -84,10 +84,7 @@ const sources = {
 const dbFile = []
 try {
   for (const lang in sources) {
-    let id = crypto.createHash('md5').update('manual' + lang).digest('base64').replace(/[\\+=\\/]/g, '').substring(0, 16)
-    while (typeof collisions[id] !== 'undefined') {
-      id = crypto.createHash('md5').update('manual' + lang + Math.random().toString()).digest('base64').replace(/[\\+=\\/]/g, '').substring(0, 16)
-    }
+    let id = generateBuildConsistentID('manual' + lang)
     const dbEntry = {
       name: sources[lang].name + ' [' + lang + ']',
       pages: [],
@@ -95,10 +92,7 @@ try {
     }
     const links = {}
     for (const source of sources[lang].pages) {
-      let id = crypto.createHash('md5').update('manual' + lang + source.file).digest('base64').replace(/[\\+=\\/]/g, '').substring(0, 16)
-      while (typeof collisions[id] !== 'undefined') {
-        id = crypto.createHash('md5').update('manual' + lang + source.file + Math.random().toString()).digest('base64').replace(/[\\+=\\/]/g, '').substring(0, 16)
-      }
+      let id = generateBuildConsistentID('manual' + lang + source.file)
       collisions[id] = true
       links[source.file] = id
     }
@@ -155,3 +149,11 @@ try {
 }
 
 write('./packs/system-doc.db', dbFile.join('\n'))
+function generateBuildConsistentID(idSource) {
+  let id = crypto.createHash('md5').update(idSource).digest('base64').replace(/[\\+=\\/]/g, '').substring(0, 16)
+  while (typeof collisions[id] !== 'undefined') {
+    id = crypto.createHash('md5').update(idSource + Math.random().toString()).digest('base64').replace(/[\\+=\\/]/g, '').substring(0, 16)
+  }
+  return id
+}
+

--- a/generate-manuals.js
+++ b/generate-manuals.js
@@ -149,6 +149,15 @@ try {
 }
 
 write('./packs/system-doc.db', dbFile.join('\n'))
+
+/**
+ * generateBuildConsistentID uses idSource to generate an id that will be consistent across builds.
+ *
+ * Note: This is called outside of foundry to build manual .db files and substitutes foundry.utils.randomID in a build consistent way.
+ * It creates a hash from the key so it is consistent between builds and the converts to base 64 so it uses the same range of characters as FoundryVTTs generator.
+ * @param {string} idSource
+ * @returns id, an string of 16 characters with the id consistently generated from idSource
+ */
 function generateBuildConsistentID(idSource) {
   let id = crypto.createHash('md5').update(idSource).digest('base64').replace(/[\\+=\\/]/g, '').substring(0, 16)
   while (typeof collisions[id] !== 'undefined') {


### PR DESCRIPTION
Extracted consistent id generation logic to it's own function 

## Description.

Replaced the 2 times the `id` is generated with a call to the new `generateBuildConsistentID` function that will generate a consistent ID from a hash of the `idSource` received.

## Motivation and Context.

Simplify a bit the code and comment the logic behind the function 

## Types of Changes.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
